### PR TITLE
Rust 1.95.0; Clippy fixes

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,14 +1,15 @@
-name: Fmt
+name: Clippy
 
 on:
   push:
 
 jobs:
-  check_fmt:
+  clippy:
+    name: cargo clippy
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - run: |
           rustup toolchain install
       - run: |
-          cargo fmt -- --check
+          cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,9 @@ jobs:
     name: cargo test
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
-        with:
-          toolchain: stable
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - run: |
+            rustup toolchain install
 
       - uses: michaelkaye/setup-matrix-synapse@main
         with:
@@ -24,9 +23,7 @@ jobs:
               "enable_registration": true
             }
 
-      - uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-        with:
-          command: test
+      - run: cargo test
         env:
           RUST_BACKTRACE: 1
           RUST_LOG: info,micro=trace,matrix=trace,ruma=trace,test=trace

--- a/microbot/src/lib.rs
+++ b/microbot/src/lib.rs
@@ -43,7 +43,7 @@ pub enum MessengerError {
     #[error("Bot has already been started")]
     AlreadyStarted,
     #[error(transparent)]
-    Builder(#[from] ClientBuildError),
+    Builder(Box<ClientBuildError>),
     #[error(transparent)]
     Client(#[from] matrix_sdk::Error),
     #[error(transparent)]
@@ -52,6 +52,12 @@ pub enum MessengerError {
     NotStarted,
     #[error("Invalid prefix")]
     PrefixConfig(regex::Error),
+}
+
+impl From<ClientBuildError> for MessengerError {
+    fn from(err: ClientBuildError) -> Self {
+        MessengerError::Builder(Box::new(err))
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -189,7 +195,7 @@ impl MatrixMessenger {
                         LoopCtrl::Continue
                     }
                 }).await
-            }.map_err(|err| MessengerError::Client(err))
+            }.map_err(MessengerError::Client)
         ));
 
         Ok(())

--- a/microbot/src/message.rs
+++ b/microbot/src/message.rs
@@ -62,33 +62,6 @@ pub(crate) struct CommandMessageParser {
     command_pattern: Regex,
 }
 
-#[derive(Debug)]
-pub(crate) struct CommandMessageParserError {
-    pub inner: regex::Error,
-}
-
-impl From<regex::Error> for CommandMessageParserError {
-    fn from(err: regex::Error) -> Self {
-        Self { inner: err }
-    }
-}
-
-impl std::fmt::Display for CommandMessageParserError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Failed to construct command message parser: {}",
-            self.inner
-        )
-    }
-}
-
-impl std::error::Error for CommandMessageParserError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&self.inner)
-    }
-}
-
 impl Default for CommandMessageParser {
     fn default() -> Self {
         Self {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]

--- a/tests/tests/bot_conversation.rs
+++ b/tests/tests/bot_conversation.rs
@@ -12,7 +12,7 @@ use tokio::sync::{
 };
 use tracing_subscriber::filter::EnvFilter;
 
-static HOMESERVER: &'static str = "http://localhost:8008";
+static HOMESERVER: &str = "http://localhost:8008";
 
 // This test configures two bots and an initial sender that will send an initial command.
 // In response to this command the two bots will command messages to the room triggering
@@ -49,7 +49,7 @@ async fn test_bot_conversation() {
         rand::rng()
             .sample_iter(&Alphanumeric)
             .take(24)
-            .map(|b| char::from(b))
+            .map(char::from)
             .collect::<String>()
     );
     let bot1 = format!(
@@ -57,7 +57,7 @@ async fn test_bot_conversation() {
         rand::rng()
             .sample_iter(&Alphanumeric)
             .take(24)
-            .map(|b| char::from(b))
+            .map(char::from)
             .collect::<String>()
     );
     let bot2 = format!(
@@ -65,7 +65,7 @@ async fn test_bot_conversation() {
         rand::rng()
             .sample_iter(&Alphanumeric)
             .take(24)
-            .map(|b| char::from(b))
+            .map(char::from)
             .collect::<String>()
     );
 
@@ -164,8 +164,6 @@ async fn test_bot_conversation() {
 
         handle1.abort();
         handle2.abort();
-
-        ()
     })
     .await
     .expect("Failed to run bot test in time");

--- a/tests/tests/ignore_old_messages.rs
+++ b/tests/tests/ignore_old_messages.rs
@@ -8,7 +8,7 @@ use rand::{distr::Alphanumeric, RngExt};
 use tokio::sync::{mpsc, mpsc::Sender};
 use tracing_subscriber::filter::EnvFilter;
 
-static HOMESERVER: &'static str = "http://localhost:8008";
+static HOMESERVER: &str = "http://localhost:8008";
 
 #[tokio::test]
 async fn test_ignores_old_messages() {
@@ -23,7 +23,7 @@ async fn test_ignores_old_messages() {
         rand::rng()
             .sample_iter(&Alphanumeric)
             .take(24)
-            .map(|b| char::from(b))
+            .map(char::from)
             .collect::<String>()
     );
     let receiver = format!(
@@ -31,7 +31,7 @@ async fn test_ignores_old_messages() {
         rand::rng()
             .sample_iter(&Alphanumeric)
             .take(24)
-            .map(|b| char::from(b))
+            .map(char::from)
             .collect::<String>()
     );
 

--- a/tests/tests/receives_command.rs
+++ b/tests/tests/receives_command.rs
@@ -8,7 +8,7 @@ use rand::{distr::Alphanumeric, RngExt};
 use tokio::sync::{mpsc, mpsc::Sender};
 use tracing_subscriber::filter::EnvFilter;
 
-static HOMESERVER: &'static str = "http://localhost:8008";
+static HOMESERVER: &str = "http://localhost:8008";
 
 #[tokio::test]
 async fn test_receives_command() {
@@ -23,7 +23,7 @@ async fn test_receives_command() {
         rand::rng()
             .sample_iter(&Alphanumeric)
             .take(24)
-            .map(|b| char::from(b))
+            .map(char::from)
             .collect::<String>()
     );
     let receiver = format!(
@@ -31,7 +31,7 @@ async fn test_receives_command() {
         rand::rng()
             .sample_iter(&Alphanumeric)
             .take(24)
-            .map(|b| char::from(b))
+            .map(char::from)
             .collect::<String>()
     );
 


### PR DESCRIPTION
- Add rust-toolchain.toml with Rust 1.95.0
- Remove dependency on `actions-rs/toolchain` and `actions-rs/cargo`
- Clippy fixes
- Enforce Clippy in CI
